### PR TITLE
Fix to show mid-tri GPA

### DIFF
--- a/gpa.js
+++ b/gpa.js
@@ -4,7 +4,7 @@ function extractLetterGrade(str){
 		if(!(str[i] >= '0' && str[i] <= '9')) s += str[i];
 		else return s;
 	}
-	if(s == "--") return "N";
+	if(s == "--" || s == "[ i ]") return "N";
 	return s;
 }
 


### PR DESCRIPTION
Powerschool made a few changes and the GPA wasn't being shown (see below)
![image](https://cloud.githubusercontent.com/assets/14072008/21514667/c0d06262-cc95-11e6-9823-cf6e5fd6b3f0.png)

Made a simple one line change to make it work again